### PR TITLE
Remove BLE Joystick component from the project

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,7 +1,0 @@
-idf_component_register(
-        SRCS "BLEManager.cpp" "BLEJoystick.cpp"
-
-        INCLUDE_DIRS "include"
-
-        REQUIRES "driver" "bt" "esp_common" "nvs_flash" "esp_hw_support" "esp_netif"
-)


### PR DESCRIPTION
The BLE Joystick component and related files have been deleted. This streamlines the project by removing unused or redundant code and dependencies.